### PR TITLE
Keep screen on during timer buzzing

### DIFF
--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -17,8 +17,8 @@ static void btnEventHandler(lv_obj_t* obj, lv_event_t event) {
   }
 }
 
-Timer::Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController)
-  : timer {timerController}, motorController {motorController} {
+Timer::Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController, System::SystemTask& systemTask)
+  : timer {timerController}, motorController {motorController}, wakeLock(systemTask) {
 
   lv_obj_t* colonLabel = lv_label_create(lv_scr_act(), nullptr);
   lv_obj_set_style_local_text_font(colonLabel, LV_LABEL_PART_MAIN, LV_STATE_DEFAULT, &jetbrains_mono_76);
@@ -108,9 +108,15 @@ void Timer::UpdateMask() {
 void Timer::Refresh() {
   if (isRinging) {
     DisplayTime();
-    // Stop buzzing after 10 seconds, but continue the counter
-    if (motorController.IsRinging() && displaySeconds.Get().count() > 10) {
-      motorController.StopRinging();
+    if (motorController.IsRinging()) {
+      // Stop buzzing after 10 seconds, but continue the counter
+      if (displaySeconds.Get().count() > 10) {
+        motorController.StopRinging();
+        wakeLock.Release();
+      // Keep the screen awake during the first 10 seconds
+      } else {
+        wakeLock.Lock();
+      }
     }
     // Reset timer after 1 minute
     if (displaySeconds.Get().count() > 60) {

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -3,6 +3,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/motor/MotorController.h"
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include "displayapp/LittleVgl.h"
 #include "displayapp/widgets/Counter.h"
 #include "utility/DirtyValue.h"
@@ -15,7 +16,7 @@ namespace Pinetime::Applications {
   namespace Screens {
     class Timer : public Screen {
     public:
-      Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController);
+      Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController, System::SystemTask& systemTask);
       ~Timer() override;
       void Refresh() override;
       void Reset();
@@ -31,6 +32,8 @@ namespace Pinetime::Applications {
       void DisplayTime();
       Pinetime::Controllers::Timer& timer;
       Pinetime::Controllers::MotorController& motorController;
+
+      Pinetime::System::WakeLock wakeLock;
 
       lv_obj_t* btnPlayPause;
       lv_obj_t* txtPlayPause;
@@ -58,7 +61,7 @@ namespace Pinetime::Applications {
     static constexpr const char* icon = Screens::Symbols::hourGlass;
 
     static Screens::Screen* Create(AppControllers& controllers) {
-      return new Screens::Timer(controllers.timer, controllers.motorController);
+      return new Screens::Timer(controllers.timer, controllers.motorController, *controllers.systemTask);
     };
   };
 }


### PR DESCRIPTION
This prevents the motorController from buzzing infinitely while the watch is sleeping.