### PR TITLE
Check the timer isn't expired (ringing) before resetting the mask

### DIFF
--- a/src/components/motor/MotorController.cpp
+++ b/src/components/motor/MotorController.cpp
@@ -34,6 +34,10 @@ void MotorController::StopRinging() {
   nrf_gpio_pin_set(PinMap::Motor);
 }
 
+bool MotorController::IsRinging() {
+  return (xTimerIsTimerActive(longVib) == pdTRUE);
+}
+
 void MotorController::StopMotor(TimerHandle_t /*xTimer*/) {
   nrf_gpio_pin_set(PinMap::Motor);
 }

--- a/src/components/motor/MotorController.h
+++ b/src/components/motor/MotorController.h
@@ -15,6 +15,7 @@ namespace Pinetime {
       void RunForDuration(uint8_t motorDuration);
       void StartRinging();
       void StopRinging();
+      bool IsRinging();
 
     private:
       static void Ring(TimerHandle_t xTimer);

--- a/src/components/timer/Timer.cpp
+++ b/src/components/timer/Timer.cpp
@@ -12,11 +12,13 @@ void Timer::StartTimer(std::chrono::milliseconds duration) {
 }
 
 std::chrono::milliseconds Timer::GetTimeRemaining() {
+  TickType_t remainingTime = 0;
   if (IsRunning()) {
-    TickType_t remainingTime = xTimerGetExpiryTime(timer) - xTaskGetTickCount();
-    return std::chrono::milliseconds(remainingTime * 1000 / configTICK_RATE_HZ);
+    remainingTime = xTimerGetExpiryTime(timer) - xTaskGetTickCount();
+  } else if (expired > 0) {
+    remainingTime = xTaskGetTickCount() - expired;
   }
-  return std::chrono::milliseconds(0);
+  return std::chrono::milliseconds(remainingTime * 1000 / configTICK_RATE_HZ);
 }
 
 void Timer::StopTimer() {
@@ -25,4 +27,12 @@ void Timer::StopTimer() {
 
 bool Timer::IsRunning() {
   return (xTimerIsTimerActive(timer) == pdTRUE);
+}
+
+void Timer::SetExpiredTime() {
+  expired = xTimerGetExpiryTime(timer);
+}
+
+void Timer::ResetExpiredTime() {
+  expired = 0;
 }

--- a/src/components/timer/Timer.h
+++ b/src/components/timer/Timer.h
@@ -19,8 +19,13 @@ namespace Pinetime {
 
       bool IsRunning();
 
+      void SetExpiredTime();
+
+      void ResetExpiredTime();
+
     private:
       TimerHandle_t timer;
+      TickType_t expired = 0;
     };
   }
 }

--- a/src/displayapp/DisplayApp.cpp
+++ b/src/displayapp/DisplayApp.cpp
@@ -365,14 +365,17 @@ void DisplayApp::Refresh() {
         if (state != States::Running) {
           PushMessageToSystemTask(System::Messages::GoToRunning);
         }
+        // Load timer app if not loaded
+        if (currentApp != Apps::Timer) {
+          LoadNewScreen(Apps::Timer, DisplayApp::FullRefreshDirections::Up);
+        }
+        // Once loaded, set the timer to ringing mode
         if (currentApp == Apps::Timer) {
           lv_disp_trig_activity(nullptr);
           auto* timer = static_cast<Screens::Timer*>(currentScreen.get());
-          timer->Reset();
-        } else {
-          LoadNewScreen(Apps::Timer, DisplayApp::FullRefreshDirections::Up);
+          timer->SetTimerRinging();
         }
-        motorController.RunForDuration(35);
+        motorController.StartRinging();
         break;
       case Messages::AlarmTriggered:
         if (currentApp == Apps::Alarm) {

--- a/src/displayapp/screens/Timer.cpp
+++ b/src/displayapp/screens/Timer.cpp
@@ -88,7 +88,7 @@ void Timer::MaskReset() {
   buttonPressing = false;
   // A click event is processed before a release event,
   // so the release event would override the "Pause" text without this check
-  if (!timer.IsRunning()) {
+  if (!timer.IsRunning() && !isRinging) {
     lv_label_set_text_static(txtPlayPause, "Start");
   }
   maskPosition = 0;

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -3,6 +3,7 @@
 #include "displayapp/screens/Screen.h"
 #include "components/motor/MotorController.h"
 #include "systemtask/SystemTask.h"
+#include "systemtask/WakeLock.h"
 #include "displayapp/LittleVgl.h"
 #include "displayapp/widgets/Counter.h"
 #include "utility/DirtyValue.h"
@@ -15,7 +16,7 @@ namespace Pinetime::Applications {
   namespace Screens {
     class Timer : public Screen {
     public:
-      Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController);
+      Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController, System::SystemTask& systemTask);
       ~Timer() override;
       void Refresh() override;
       void Reset();
@@ -31,6 +32,8 @@ namespace Pinetime::Applications {
       void DisplayTime();
       Pinetime::Controllers::Timer& timer;
       Pinetime::Controllers::MotorController& motorController;
+
+      Pinetime::System::WakeLock wakeLock;
 
       lv_obj_t* btnPlayPause;
       lv_obj_t* txtPlayPause;
@@ -58,7 +61,7 @@ namespace Pinetime::Applications {
     static constexpr const char* icon = Screens::Symbols::hourGlass;
 
     static Screens::Screen* Create(AppControllers& controllers) {
-      return new Screens::Timer(controllers.timer, controllers.motorController);
+      return new Screens::Timer(controllers.timer, controllers.motorController, *controllers.systemTask);
     };
   };
 }

--- a/src/displayapp/screens/Timer.h
+++ b/src/displayapp/screens/Timer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "displayapp/screens/Screen.h"
+#include "components/motor/MotorController.h"
 #include "systemtask/SystemTask.h"
 #include "displayapp/LittleVgl.h"
 #include "displayapp/widgets/Counter.h"
@@ -14,13 +15,14 @@ namespace Pinetime::Applications {
   namespace Screens {
     class Timer : public Screen {
     public:
-      Timer(Controllers::Timer& timerController);
+      Timer(Controllers::Timer& timerController, Controllers::MotorController& motorController);
       ~Timer() override;
       void Refresh() override;
       void Reset();
       void ToggleRunning();
       void ButtonPressed();
       void MaskReset();
+      void SetTimerRinging();
 
     private:
       void SetTimerRunning();
@@ -28,6 +30,7 @@ namespace Pinetime::Applications {
       void UpdateMask();
       void DisplayTime();
       Pinetime::Controllers::Timer& timer;
+      Pinetime::Controllers::MotorController& motorController;
 
       lv_obj_t* btnPlayPause;
       lv_obj_t* txtPlayPause;
@@ -42,6 +45,7 @@ namespace Pinetime::Applications {
       Widgets::Counter secondCounter = Widgets::Counter(0, 59, jetbrains_mono_76);
 
       bool buttonPressing = false;
+      bool isRinging = false;
       lv_coord_t maskPosition = 0;
       TickType_t pressTime = 0;
       Utility::DirtyValue<std::chrono::seconds> displaySeconds;
@@ -54,7 +58,7 @@ namespace Pinetime::Applications {
     static constexpr const char* icon = Screens::Symbols::hourGlass;
 
     static Screens::Screen* Create(AppControllers& controllers) {
-      return new Screens::Timer(controllers.timer);
+      return new Screens::Timer(controllers.timer, controllers.motorController);
     };
   };
 }


### PR DESCRIPTION
Previously you could set the "reset" text for the expired timer to start by holding down and releasing:
![broken_reset_button](https://github.com/user-attachments/assets/f9aa4d86-8fa2-46be-bda2-f95ff937b18b)

This fixes that by checking the expired timer isn't ringing before allowing the mask to be reset:
![fixed_reset_button_bug](https://github.com/user-attachments/assets/f54b93d8-c9cf-449b-95b5-514a32d5ef33)
